### PR TITLE
Data showing from API calls, and moved API calls to results page only.

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -219,7 +219,7 @@ input:focus {
   width: 100%;
   height: 100%;
   position: absolute;
-  /* top: 0; */
+  top: 0;
   opacity: 0.5;
   z-index: -2;
   background-size: cover;

--- a/client/src/components/HomePage/FilterCheckboxes.jsx
+++ b/client/src/components/HomePage/FilterCheckboxes.jsx
@@ -1,36 +1,36 @@
 export default function FilterCheckboxes({
-  longestGame,
-  setLongestGame,
-  shortestGame,
-  setShortestGame,
+  longestMatch,
+  setLongestMatch,
+  shortestMatch,
+  setShortestMatch,
 }) {
   return (
     <div className="filter-options">
       <div>
         <input
           type="checkbox"
-          id="longestGame"
-          name="longestGame"
-          checked={longestGame}
+          id="longestMatch"
+          name="longestMatch"
+          checked={longestMatch}
           onChange={(event) => {
-            setLongestGame(event.target.checked);
-            console.log("Longest Game:", event.target.checked);
+            setLongestMatch(event.target.checked);
+            console.log("Longest Match:", event.target.checked);
           }}
         />
-        <label htmlFor="longestGame">Longest Game</label>
+        <label htmlFor="longestMatch">Longest Match</label>
       </div>
       <div>
         <input
           type="checkbox"
-          id="shortestGame"
-          name="shortestGame"
-          checked={shortestGame}
+          id="shortestMatch"
+          name="shortestMatch"
+          checked={shortestMatch}
           onChange={(event) => {
-            setShortestGame(event.target.checked);
-            console.log("Shortest Game:", event.target.checked);
+            setShortestMatch(event.target.checked);
+            console.log("Shortest Match:", event.target.checked);
           }}
         />
-        <label htmlFor="shortestGame">Shortest Game</label>
+        <label htmlFor="shortestMatch">Shortest Match</label>
       </div>
     </div>
   );

--- a/client/src/components/HomePage/SearchModal.jsx
+++ b/client/src/components/HomePage/SearchModal.jsx
@@ -7,8 +7,8 @@ import FilterCheckboxes from "./FilterCheckboxes";
 export default function SearchModal({ showModal, setShowModal }) {
   const [showFilter, setShowFilter] = useState(false);
   const [steamId, setSteamId] = useState("");
-  const [longestGame, setLongestGame] = useState(false);
-  const [shortestGame, setShortestGame] = useState(false);
+  const [longestMatch, setLongestMatch] = useState(false);
+  const [shortestMatch, setShortestMatch] = useState(false);
 
   // useNavigate hook allows for navigation to different parts of application
   const navigate = useNavigate();
@@ -16,7 +16,7 @@ export default function SearchModal({ showModal, setShowModal }) {
   const search = async () => {
     const data = await playerIdSearch(steamId);
     // takes 2 args, path which is required, and optional state object
-    navigate("/results", { state: { steamId, longestGame, shortestGame } });
+    navigate("/results", { state: { steamId, longestMatch, shortestMatch } });
   };
 
   const handleKeyDown = (event) => {
@@ -55,10 +55,10 @@ export default function SearchModal({ showModal, setShowModal }) {
             </button>
             {showFilter && (
               <FilterCheckboxes
-                longestGame={longestGame}
-                setLongestGame={setLongestGame}
-                shortestGame={shortestGame}
-                setShortestGame={setShortestGame}
+                longestMatch={longestMatch}
+                setLongestMatch={setLongestMatch}
+                shortestMatch={shortestMatch}
+                setShortestMatch={setShortestMatch}
               />
             )}
           </div>

--- a/client/src/components/HomePage/SearchModal.jsx
+++ b/client/src/components/HomePage/SearchModal.jsx
@@ -13,8 +13,7 @@ export default function SearchModal({ showModal, setShowModal }) {
   // useNavigate hook allows for navigation to different parts of application
   const navigate = useNavigate();
 
-  const search = async () => {
-    const data = await playerIdSearch(steamId);
+  const search = () => {
     // takes 2 args, path which is required, and optional state object
     navigate("/results", { state: { steamId, longestMatch, shortestMatch } });
   };

--- a/client/src/components/ResultsDisplay.jsx/MatchData.jsx
+++ b/client/src/components/ResultsDisplay.jsx/MatchData.jsx
@@ -1,9 +1,14 @@
 import { useState, useEffect } from "react";
 
-export default function MatchData({ matches, longestGame, shortestGame }) {
+export default function MatchData({
+  matches,
+  longestMatch,
+  shortestMatch,
+  heroes,
+}) {
   // longestMatchData and shortestMatchData store the actual data to be displayed
-  const [longestMatchData, setLongestMatchData] = useState(null);
-  const [shortestMatchData, setShortestMatchData] = useState(null);
+  const [longestMatchData, setLongestMatchData] = useState({});
+  const [shortestMatchData, setShortestMatchData] = useState({});
 
   useEffect(() => {
     if (matches.length > 0) {
@@ -19,6 +24,9 @@ export default function MatchData({ matches, longestGame, shortestGame }) {
         }
       }
 
+      longest.duration = Math.round(longest.duration / 60);
+      shortest.duration = Math.round(shortest.duration / 60);
+
       console.log(longest);
       console.log(shortest);
 
@@ -29,16 +37,43 @@ export default function MatchData({ matches, longestGame, shortestGame }) {
 
   return (
     <div>
-      {longestGame && longestMatchData && (
+      {longestMatch && longestMatchData && (
         <div>
           <h2>Longest Match</h2>
-          <p>Duration: {longestMatchData.duration}</p>
+          <p>Match ID: {longestMatchData.match_id}</p>
+          <p>Duration: {longestMatchData.duration} Minutes</p>
+          {heroes.length > 0 && (
+            <p>
+              {`Hero: 
+              ${
+                heroes.find((hero) => hero.id === longestMatchData.hero_id)
+                  .localized_name
+              }`}
+            </p>
+          )}
+          <p>
+            KDA: {longestMatchData.kills}/{longestMatchData.deaths}/
+            {longestMatchData.assists}
+          </p>
         </div>
       )}
-      {shortestGame && shortestMatchData && (
+      {shortestMatch && shortestMatchData && (
         <div>
           <h2>Shortest Match</h2>
-          <p>Duration: {shortestMatchData.duration}</p>
+          <p>Match ID: {shortestMatchData.match_id}</p>
+          <p>Duration: {shortestMatchData.duration} Minutes</p>
+          {heroes.length > 0 && (
+            <p>
+              {`Hero: ${
+                heroes.find((hero) => hero.id === shortestMatchData.hero_id)
+                  .localized_name
+              }`}
+            </p>
+          )}
+          <p>
+            KDA: {shortestMatchData.kills}/{shortestMatchData.deaths}/
+            {shortestMatchData.assists}
+          </p>
         </div>
       )}
     </div>

--- a/client/src/components/ResultsDisplay.jsx/MatchData.jsx
+++ b/client/src/components/ResultsDisplay.jsx/MatchData.jsx
@@ -42,14 +42,20 @@ export default function MatchData({
           <h2>Longest Match</h2>
           <p>Match ID: {longestMatchData.match_id}</p>
           <p>Duration: {longestMatchData.duration} Minutes</p>
-          {heroes.length > 0 && (
-            <p>
-              {`Hero: 
-              ${
-                heroes.find((hero) => hero.id === longestMatchData.hero_id)
-                  .localized_name
-              }`}
-            </p>
+          {heroes[longestMatchData.hero_id] && (
+            <>
+              <div>
+                <p>Hero: {heroes[longestMatchData.hero_id].localized_name}</p>
+              </div>
+              <div>
+                <img
+                  src={`https://cdn.dota2.com${
+                    heroes[longestMatchData.hero_id].img
+                  }`}
+                  alt={heroes[longestMatchData.hero_id].localized_name}
+                />
+              </div>
+            </>
           )}
           <p>
             KDA: {longestMatchData.kills}/{longestMatchData.deaths}/
@@ -62,13 +68,20 @@ export default function MatchData({
           <h2>Shortest Match</h2>
           <p>Match ID: {shortestMatchData.match_id}</p>
           <p>Duration: {shortestMatchData.duration} Minutes</p>
-          {heroes.length > 0 && (
-            <p>
-              {`Hero: ${
-                heroes.find((hero) => hero.id === shortestMatchData.hero_id)
-                  .localized_name
-              }`}
-            </p>
+          {heroes[shortestMatchData.hero_id] && (
+            <>
+              <div>
+                <p>Hero: {heroes[shortestMatchData.hero_id].localized_name}</p>
+              </div>
+              <div>
+                <img
+                  src={`https://cdn.dota2.com${
+                    heroes[shortestMatchData.hero_id].img
+                  }`}
+                  alt={heroes[shortestMatchData.hero_id].localized_name}
+                />
+              </div>
+            </>
           )}
           <p>
             KDA: {shortestMatchData.kills}/{shortestMatchData.deaths}/

--- a/client/src/components/ResultsDisplay.jsx/index.jsx
+++ b/client/src/components/ResultsDisplay.jsx/index.jsx
@@ -1,25 +1,28 @@
 import { useState, useEffect } from "react";
 import { useLocation } from "react-router-dom";
-import { playerIdSearch } from "../../utils/API";
+import { playerIdSearch, fetchHeroes } from "../../utils/API";
 
 import MatchData from "./MatchData";
 
 export default function ResultsDisplay() {
   const [results, setResults] = useState([]);
+  const [heroes, setHeroes] = useState([]);
 
   const location = useLocation();
   // Check if location.state exists before trying to access steamId
   const steamId = location.state ? location.state.steamId : null;
 
-  // longestGame and shortestGame control state and if it is displayed
-  const longestGame = location.state ? location.state.longestGame : false;
-  const shortestGame = location.state ? location.state.shortestGame : false;
+  // longestMatch and shortestMatch control state and if it is displayed
+  const longestMatch = location.state ? location.state.longestMatch : false;
+  const shortestMatch = location.state ? location.state.shortestMatch : false;
 
   useEffect(() => {
     async function fetchData() {
       try {
         const data = await playerIdSearch(steamId);
         setResults(data);
+        const heroesData = await fetchHeroes();
+        setHeroes(heroesData);
       } catch (error) {
         console.error(error);
       }
@@ -38,8 +41,9 @@ export default function ResultsDisplay() {
       <MatchData
         matches={results}
         steamId={steamId}
-        longestGame={longestGame}
-        shortestGame={shortestGame}
+        longestMatch={longestMatch}
+        shortestMatch={shortestMatch}
+        heroes={heroes}
       />
       {/* {results &&
         results.map((result) => (

--- a/client/src/components/ResultsDisplay.jsx/index.jsx
+++ b/client/src/components/ResultsDisplay.jsx/index.jsx
@@ -19,10 +19,12 @@ export default function ResultsDisplay() {
   useEffect(() => {
     async function fetchData() {
       try {
-        const data = await playerIdSearch(steamId);
-        setResults(data);
-        const heroesData = await fetchHeroes();
-        setHeroes(heroesData);
+        if (steamId) {
+          const data = await playerIdSearch(steamId);
+          setResults(data);
+          const heroesData = await fetchHeroes();
+          setHeroes(heroesData);
+        }
       } catch (error) {
         console.error(error);
       }

--- a/client/src/components/ResultsDisplay.jsx/index.jsx
+++ b/client/src/components/ResultsDisplay.jsx/index.jsx
@@ -9,12 +9,13 @@ export default function ResultsDisplay() {
   const [heroes, setHeroes] = useState([]);
 
   const location = useLocation();
-  // Check if location.state exists before trying to access steamId
-  const steamId = location.state ? location.state.steamId : null;
 
-  // longestMatch and shortestMatch control state and if it is displayed
-  const longestMatch = location.state ? location.state.longestMatch : false;
-  const shortestMatch = location.state ? location.state.shortestMatch : false;
+  let steamId, longestMatch, shortestMatch;
+
+  // Checks if location.state exists as they are undefined before if no state is passed in
+  if (location.state) {
+    ({ steamId, longestMatch, shortestMatch } = location.state);
+  }
 
   useEffect(() => {
     async function fetchData() {

--- a/client/src/pages/Results.jsx
+++ b/client/src/pages/Results.jsx
@@ -3,7 +3,8 @@ import ResultsDisplay from "../components/ResultsDisplay.jsx";
 export default function Results() {
   return (
     <div className="container">
-      <div className="bgResultsPage">
+      <div className="bgResultsPage"></div>
+      <div className="results-container">
         <ResultsDisplay />
       </div>
     </div>

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -23,3 +23,13 @@ export async function playerIdSearch(accountId) {
     console.error(error);
   }
 }
+
+export async function fetchHeroes() {
+  try {
+    const response = await axios.get(`https://api.opendota.com/api/heroes`);
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+}

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -26,7 +26,9 @@ export async function playerIdSearch(accountId) {
 
 export async function fetchHeroes() {
   try {
-    const response = await axios.get(`https://api.opendota.com/api/heroes`);
+    const response = await axios.get(
+      `https://raw.githubusercontent.com/odota/dotaconstants/master/build/heroes.json`
+    );
     console.log(response.data);
     return response.data;
   } catch (error) {


### PR DESCRIPTION
- Fixed background image for results page.
- Renamed all the "Game" to "Matches" for visual clarity on filter checkboxes and modal.
- Heroes state and call from fetchHeroes API call added to ResultsDisplay.
- Duration of matches, match ID, hero image, and KDA added to results after API call.
- 2 API calls are made from the results page so far for hero data and specific steam user ID's.
- API call from modal moved to results page to cut down on amount of API calls.
- Added conditional for when there isn't a state before steamId is passed in to results page.