### PR TITLE
Working on results page CSS and API data  

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -42,6 +42,10 @@ input:focus {
   outline-color: var(--bkrd-color);
 }
 
+p {
+  font-size: 20px;
+}
+
 /* Nav Bar CSS */
 
 .nav {
@@ -254,6 +258,41 @@ input:focus {
   background-size: cover;
   background-position: center;
   background-image: url("../src/assets/images/dota-sky-background.jpg");
+}
+
+.profile-div {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  background-color: rgba(0, 0, 0, 0.5);
+  border: 2px solid var(--bkrd-color);
+}
+
+.steam-pic {
+  border: 2px solid var(--font-color);
+}
+
+.profile-description-div {
+  width: 80%;
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+  margin-bottom: 20px;
+  /* flex-direction: column; */
+}
+
+.profile-text {
+  height: 100%;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+}
+
+.match-description-div {
+  display: flex;
+  flex-direction: row;
 }
 
 @media (max-width: 1000px) {

--- a/client/src/components/HomePage/SearchModal.jsx
+++ b/client/src/components/HomePage/SearchModal.jsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { playerIdSearch } from "../../utils/API";
 
 import FilterCheckboxes from "./FilterCheckboxes";
 

--- a/client/src/components/ResultsDisplay.jsx/MatchData.jsx
+++ b/client/src/components/ResultsDisplay.jsx/MatchData.jsx
@@ -40,11 +40,11 @@ export default function MatchData({
   }, [matches]);
 
   if (!profile || !profile.profile) {
-    return;
+    return null;
   }
 
   return (
-    <div>
+    <>
       {profile && <ProfileData profile={profile} />}
       {longestMatch && longestMatchData && (
         <MatchDataMap
@@ -60,6 +60,6 @@ export default function MatchData({
           heroes={heroes}
         />
       )}
-    </div>
+    </>
   );
 }

--- a/client/src/components/ResultsDisplay.jsx/MatchData.jsx
+++ b/client/src/components/ResultsDisplay.jsx/MatchData.jsx
@@ -1,6 +1,10 @@
 import { useState, useEffect } from "react";
 
+import ProfileData from "./ProfileData";
+import MatchDataMap from "./MatchDataMap";
+
 export default function MatchData({
+  profile,
   matches,
   longestMatch,
   shortestMatch,
@@ -35,59 +39,26 @@ export default function MatchData({
     }
   }, [matches]);
 
+  if (!profile || !profile.profile) {
+    return;
+  }
+
   return (
     <div>
+      {profile && <ProfileData profile={profile} />}
       {longestMatch && longestMatchData && (
-        <div>
-          <h2>Longest Match</h2>
-          <p>Match ID: {longestMatchData.match_id}</p>
-          <p>Duration: {longestMatchData.duration} Minutes</p>
-          {heroes[longestMatchData.hero_id] && (
-            <>
-              <div>
-                <p>Hero: {heroes[longestMatchData.hero_id].localized_name}</p>
-              </div>
-              <div>
-                <img
-                  src={`https://cdn.dota2.com${
-                    heroes[longestMatchData.hero_id].img
-                  }`}
-                  alt={heroes[longestMatchData.hero_id].localized_name}
-                />
-              </div>
-            </>
-          )}
-          <p>
-            KDA: {longestMatchData.kills}/{longestMatchData.deaths}/
-            {longestMatchData.assists}
-          </p>
-        </div>
+        <MatchDataMap
+          matchData={longestMatchData}
+          matchTitle="Longest Match"
+          heroes={heroes}
+        />
       )}
       {shortestMatch && shortestMatchData && (
-        <div>
-          <h2>Shortest Match</h2>
-          <p>Match ID: {shortestMatchData.match_id}</p>
-          <p>Duration: {shortestMatchData.duration} Minutes</p>
-          {heroes[shortestMatchData.hero_id] && (
-            <>
-              <div>
-                <p>Hero: {heroes[shortestMatchData.hero_id].localized_name}</p>
-              </div>
-              <div>
-                <img
-                  src={`https://cdn.dota2.com${
-                    heroes[shortestMatchData.hero_id].img
-                  }`}
-                  alt={heroes[shortestMatchData.hero_id].localized_name}
-                />
-              </div>
-            </>
-          )}
-          <p>
-            KDA: {shortestMatchData.kills}/{shortestMatchData.deaths}/
-            {shortestMatchData.assists}
-          </p>
-        </div>
+        <MatchDataMap
+          matchData={shortestMatchData}
+          matchTitle="Shortest Match"
+          heroes={heroes}
+        />
       )}
     </div>
   );

--- a/client/src/components/ResultsDisplay.jsx/MatchDataMap.jsx
+++ b/client/src/components/ResultsDisplay.jsx/MatchDataMap.jsx
@@ -1,24 +1,39 @@
 export default function MatchDataMap({ matchData, matchTitle, heroes }) {
   return (
-    <div>
-      <h2>Match ID: {matchTitle}</h2>
-      <p>Duration: {matchData.duration} Minutes</p>
-      {heroes[matchData.hero_id] && (
-        <>
-          <div>
-            <p>Hero: {heroes[matchData.hero_id].localized_name}</p>
-          </div>
-          <div>
-            <img
-              src={`https://cdn.dota2.com${heroes[matchData.hero_id].img}`}
-              alt={heroes[matchData.hero_id].localized_name}
-            />
-          </div>
-        </>
-      )}
-      <p>
-        KDA: {matchData.kills}/{matchData.deaths}/{matchData.assists}
-      </p>
+    <div className="profile-div">
+      <h2>{matchTitle}</h2>
+      <h3>{matchData.match_id}</h3>
+      <h4>{matchData.duration} Minutes</h4>
+      <table>
+        <thead>
+          <tr>
+            <th>Hero</th>
+            <th>Kills</th>
+            <th>Deaths</th>
+            <th>Assists</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              {heroes[matchData.hero_id] && (
+                <>
+                  <img
+                    src={`https://cdn.dota2.com${
+                      heroes[matchData.hero_id].img
+                    }`}
+                    alt={heroes[matchData.hero_id].localized_name}
+                  />
+                  {heroes[matchData.hero_id].localized_name}
+                </>
+              )}
+            </td>
+            <td>{matchData.kills}</td>
+            <td>{matchData.deaths}</td>
+            <td>{matchData.assists}</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/client/src/components/ResultsDisplay.jsx/MatchDataMap.jsx
+++ b/client/src/components/ResultsDisplay.jsx/MatchDataMap.jsx
@@ -1,0 +1,24 @@
+export default function MatchDataMap({ matchData, matchTitle, heroes }) {
+  return (
+    <div>
+      <h2>Match ID: {matchTitle}</h2>
+      <p>Duration: {matchData.duration} Minutes</p>
+      {heroes[matchData.hero_id] && (
+        <>
+          <div>
+            <p>Hero: {heroes[matchData.hero_id].localized_name}</p>
+          </div>
+          <div>
+            <img
+              src={`https://cdn.dota2.com${heroes[matchData.hero_id].img}`}
+              alt={heroes[matchData.hero_id].localized_name}
+            />
+          </div>
+        </>
+      )}
+      <p>
+        KDA: {matchData.kills}/{matchData.deaths}/{matchData.assists}
+      </p>
+    </div>
+  );
+}

--- a/client/src/components/ResultsDisplay.jsx/ProfileData.jsx
+++ b/client/src/components/ResultsDisplay.jsx/ProfileData.jsx
@@ -1,14 +1,34 @@
 export default function ProfileData({ profile }) {
   return (
-    <div>
+    <div className="profile-div">
       <h2>Steam Profile</h2>
-      <p>Profile URL: {profile.profile.profileurl}</p>
-      <img src={profile.profile.avatarfull} alt={profile.profile.personaname} />
-      <p>Steam Username: {profile.profile.personaname}</p>
-      <p>Rank Distribution: {profile.rank_tier} Percentile</p>
       <p>
-        Current Dota Plus Subscription: {profile.profile.plus ? "Yes" : "No"}
+        Profile URL:{" "}
+        <a
+          href={profile.profile.profileurl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {profile.profile.profileurl}
+        </a>
       </p>
+      <div className="profile-description-div">
+        <div>
+          <img
+            src={profile.profile.avatarfull}
+            alt={profile.profile.personaname}
+            className="steam-pic"
+          />
+        </div>
+        <div className="profile-text">
+          <p>Steam Username: {profile.profile.personaname}</p>
+          <p>Rank Distribution: {profile.rank_tier} Percentile</p>
+          <p>
+            Current Dota Plus Subscription:{" "}
+            {profile.profile.plus ? "Yes" : "No"}
+          </p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/client/src/components/ResultsDisplay.jsx/ProfileData.jsx
+++ b/client/src/components/ResultsDisplay.jsx/ProfileData.jsx
@@ -1,0 +1,14 @@
+export default function ProfileData({ profile }) {
+  return (
+    <div>
+      <h2>Steam Profile</h2>
+      <p>Profile URL: {profile.profile.profileurl}</p>
+      <img src={profile.profile.avatarfull} alt={profile.profile.personaname} />
+      <p>Steam Username: {profile.profile.personaname}</p>
+      <p>Rank Distribution: {profile.rank_tier} Percentile</p>
+      <p>
+        Current Dota Plus Subscription: {profile.profile.plus ? "Yes" : "No"}
+      </p>
+    </div>
+  );
+}

--- a/client/src/components/ResultsDisplay.jsx/index.jsx
+++ b/client/src/components/ResultsDisplay.jsx/index.jsx
@@ -1,10 +1,15 @@
 import { useState, useEffect } from "react";
 import { useLocation } from "react-router-dom";
-import { playerIdSearch, fetchHeroes } from "../../utils/API";
+import {
+  playerProfileSearch,
+  playerIdSearch,
+  fetchHeroes,
+} from "../../utils/API";
 
 import MatchData from "./MatchData";
 
 export default function ResultsDisplay() {
+  const [profile, setProfile] = useState([]);
   const [results, setResults] = useState([]);
   const [heroes, setHeroes] = useState([]);
 
@@ -21,10 +26,15 @@ export default function ResultsDisplay() {
     async function fetchData() {
       try {
         if (steamId) {
-          const data = await playerIdSearch(steamId);
-          setResults(data);
-          const heroesData = await fetchHeroes();
-          setHeroes(heroesData);
+          const user = await playerProfileSearch(steamId);
+          setProfile(user);
+
+          if (longestMatch || shortestMatch) {
+            const data = await playerIdSearch(steamId);
+            setResults(data);
+            const heroesData = await fetchHeroes();
+            setHeroes(heroesData);
+          }
         }
       } catch (error) {
         console.error(error);
@@ -32,7 +42,7 @@ export default function ResultsDisplay() {
     }
 
     fetchData();
-  }, [steamId]);
+  }, [steamId, longestMatch, shortestMatch]);
 
   if (!steamId) {
     return <h1>Please enter a Steam ID in the search bar.</h1>;
@@ -42,6 +52,7 @@ export default function ResultsDisplay() {
     <div>
       <h1>Search Results</h1>
       <MatchData
+        profile={profile}
         matches={results}
         steamId={steamId}
         longestMatch={longestMatch}

--- a/client/src/components/ResultsDisplay.jsx/index.jsx
+++ b/client/src/components/ResultsDisplay.jsx/index.jsx
@@ -49,8 +49,8 @@ export default function ResultsDisplay() {
   }
 
   return (
-    <div>
-      <h1>Search Results</h1>
+    <div className="results-container">
+      {/* <h1>Search Results</h1> */}
       <MatchData
         profile={profile}
         matches={results}

--- a/client/src/pages/Results.jsx
+++ b/client/src/pages/Results.jsx
@@ -4,9 +4,8 @@ export default function Results() {
   return (
     <div className="container">
       <div className="bgResultsPage"></div>
-      <div className="results-container">
-        <ResultsDisplay />
-      </div>
+
+      <ResultsDisplay />
     </div>
   );
 }

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -2,16 +2,35 @@ import axios from "axios";
 
 // Converts SteamID64 to SteamID3, without brackets and only numbers
 // Reference used https://gist.github.com/bcahue/4eae86ae1d10364bb66d
-export async function playerIdSearch(accountId) {
+export function convertedSteamId(accountId) {
   if (!accountId) {
     return;
   }
+
   // Uses regular expression to find any digit 0-9 \d + all occurences in string g for global.
   // Returns array matching one or more digits in accountId string using join method with empty string.
   let num = accountId.match(/\d+/g).join("");
   let steamId64 = 76561197960265728n;
   let steamCalc = BigInt(num) - steamId64;
-  let convertedId = steamCalc.toString();
+  return steamCalc.toString();
+}
+
+export async function playerProfileSearch(accountId) {
+  let convertedId = convertedSteamId(accountId);
+
+  try {
+    const response = await axios.get(
+      `https://api.opendota.com/api/players/${convertedId}`
+    );
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+export async function playerIdSearch(accountId) {
+  let convertedId = convertedSteamId(accountId);
 
   try {
     const response = await axios.get(


### PR DESCRIPTION
- Created ProfileData and MatchDataMap for more modular components.
- Added error handling for profile, and imported ProfileData and MatchDataMap into MatchData.
- ProfileData always displays when there is a search regardless of if there are filter options yet. Helpful for when there's no options selected.
- MatchDataMap uses a table format to display stats, so far only for longest and shortest game.
- Added conditional for longest and shortest match in ResultsDisplay so it doesn't call longest and shortest match each time.
- Added another API request to get steam profile data based off data inside opendota api for players.