### PR TITLE
Matches API data now showing stats from specific match

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -46,6 +46,10 @@ p {
   font-size: 20px;
 }
 
+td {
+  text-align: center;
+}
+
 /* Nav Bar CSS */
 
 .nav {
@@ -265,6 +269,7 @@ p {
   justify-content: center;
   align-items: center;
   flex-direction: column;
+  margin-top: 20px;
   background-color: rgba(0, 0, 0, 0.5);
   border: 2px solid var(--bkrd-color);
 }
@@ -290,9 +295,35 @@ p {
   flex-direction: column;
 }
 
+.match-title {
+  margin-top: 10px;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.match-id {
+  margin-top: 5px;
+}
+
+.match-duration {
+  margin: 5px 0px;
+}
+
 .match-description-div {
   display: flex;
   flex-direction: row;
+}
+
+.hero-img-name img {
+  height: 60%;
+  object-fit: cover;
+}
+
+.hero-img-name {
+  height: 50px;
+  display: flex;
+  align-items: center;
+  flex-direction: column-reverse;
 }
 
 @media (max-width: 1000px) {

--- a/client/src/components/ResultsDisplay.jsx/MatchData.jsx
+++ b/client/src/components/ResultsDisplay.jsx/MatchData.jsx
@@ -11,13 +11,9 @@ export default function MatchData({
   shortestMatch,
   heroes,
 }) {
-  // longestMatchData and shortestMatchData store the actual data to be displayed
-  const [longestFromAllMatches, setLongestFromAllMatches] = useState({});
-  const [shortestFromAllMatches, setShortestFromAllMatches] = useState({});
-
   // Specific matches use different API call for more indepth information on a match
-  const [specificLongestMatch, setSpecificLongestMatch] = useState({});
-  const [specificShortestMatch, setSpecificShortestMatch] = useState({});
+  const [specificLongestMatch, setSpecificLongestMatch] = useState([]);
+  const [specificShortestMatch, setSpecificShortestMatch] = useState([]);
 
   useEffect(() => {
     // Reuse this for longest or shortest API call.
@@ -51,10 +47,6 @@ export default function MatchData({
         console.log(shortest);
         console.log(longest.match_id);
 
-        // Sets the state of these equal to longest and shortest array from all matches
-        setLongestFromAllMatches(longest);
-        setShortestFromAllMatches(shortest);
-
         // If longest and shortest match are truthy, fetches match by its id.
         if (longestMatch) {
           const longestMatchData = await fetchMatchData(longest.match_id);
@@ -71,26 +63,23 @@ export default function MatchData({
   }, [matches, longestMatch, shortestMatch]);
 
   if (!profile || !profile.profile) {
-    return null;
+    return;
   }
 
   return (
     <>
       {/* Uses both matchData and specificMatchData from different API calls. */}
       {profile && <ProfileData profile={profile} />}
-      {longestMatch && longestFromAllMatches && (
+      {longestMatch && (
         <MatchDataMap
-          matchData={longestFromAllMatches}
-          specificLongestMatch={specificLongestMatch}
+          specificMatchData={specificLongestMatch}
           matchTitle="Longest Match"
           heroes={heroes}
         />
       )}
-      {shortestMatch && shortestFromAllMatches && (
+      {shortestMatch && (
         <MatchDataMap
-          matchData={shortestFromAllMatches}
-          specificShortestMatch={specificShortestMatch}
-          specifc
+          specificMatchData={specificShortestMatch}
           matchTitle="Shortest Match"
           heroes={heroes}
         />

--- a/client/src/components/ResultsDisplay.jsx/MatchData.jsx
+++ b/client/src/components/ResultsDisplay.jsx/MatchData.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { fetchMatch } from "../../utils/API";
 
 import ProfileData from "./ProfileData";
 import MatchDataMap from "./MatchDataMap";
@@ -11,33 +12,63 @@ export default function MatchData({
   heroes,
 }) {
   // longestMatchData and shortestMatchData store the actual data to be displayed
-  const [longestMatchData, setLongestMatchData] = useState({});
-  const [shortestMatchData, setShortestMatchData] = useState({});
+  const [longestFromAllMatches, setLongestFromAllMatches] = useState({});
+  const [shortestFromAllMatches, setShortestFromAllMatches] = useState({});
+
+  // Specific matches use different API call for more indepth information on a match
+  const [specificLongestMatch, setSpecificLongestMatch] = useState({});
+  const [specificShortestMatch, setSpecificShortestMatch] = useState({});
 
   useEffect(() => {
-    if (matches.length > 0) {
-      let longest = matches[0];
-      let shortest = matches[0];
+    // Reuse this for longest or shortest API call.
+    const fetchMatchData = async (match_id) => {
+      try {
+        const data = await fetchMatch(match_id);
+        return data;
+      } catch (error) {
+        console.error(error);
+      }
+    };
 
-      for (let i = 0; i < matches.length; i++) {
-        if (matches[i].duration > longest.duration) {
-          longest = matches[i];
+    const fetchMatches = async () => {
+      if (matches.length > 0) {
+        let longest = matches[0];
+        let shortest = matches[0];
+
+        for (let i = 0; i < matches.length; i++) {
+          if (matches[i].duration > longest.duration) {
+            longest = matches[i];
+          }
+          if (matches[i].duration < shortest.duration) {
+            shortest = matches[i];
+          }
         }
-        if (matches[i].duration < shortest.duration) {
-          shortest = matches[i];
+
+        longest.duration = Math.round(longest.duration / 60);
+        shortest.duration = Math.round(shortest.duration / 60);
+
+        console.log(longest);
+        console.log(shortest);
+        console.log(longest.match_id);
+
+        // Sets the state of these equal to longest and shortest array from all matches
+        setLongestFromAllMatches(longest);
+        setShortestFromAllMatches(shortest);
+
+        // If longest and shortest match are truthy, fetches match by its id.
+        if (longestMatch) {
+          const longestMatchData = await fetchMatchData(longest.match_id);
+          setSpecificLongestMatch(longestMatchData);
+        }
+        if (shortestMatch) {
+          const shortestMatchData = await fetchMatchData(shortest.match_id);
+          setSpecificShortestMatch(shortestMatchData);
         }
       }
+    };
 
-      longest.duration = Math.round(longest.duration / 60);
-      shortest.duration = Math.round(shortest.duration / 60);
-
-      console.log(longest);
-      console.log(shortest);
-
-      setLongestMatchData(longest);
-      setShortestMatchData(shortest);
-    }
-  }, [matches]);
+    fetchMatches();
+  }, [matches, longestMatch, shortestMatch]);
 
   if (!profile || !profile.profile) {
     return null;
@@ -45,17 +76,21 @@ export default function MatchData({
 
   return (
     <>
+      {/* Uses both matchData and specificMatchData from different API calls. */}
       {profile && <ProfileData profile={profile} />}
-      {longestMatch && longestMatchData && (
+      {longestMatch && longestFromAllMatches && (
         <MatchDataMap
-          matchData={longestMatchData}
+          matchData={longestFromAllMatches}
+          specificLongestMatch={specificLongestMatch}
           matchTitle="Longest Match"
           heroes={heroes}
         />
       )}
-      {shortestMatch && shortestMatchData && (
+      {shortestMatch && shortestFromAllMatches && (
         <MatchDataMap
-          matchData={shortestMatchData}
+          matchData={shortestFromAllMatches}
+          specificShortestMatch={specificShortestMatch}
+          specifc
           matchTitle="Shortest Match"
           heroes={heroes}
         />

--- a/client/src/components/ResultsDisplay.jsx/MatchDataMap.jsx
+++ b/client/src/components/ResultsDisplay.jsx/MatchDataMap.jsx
@@ -1,39 +1,131 @@
-export default function MatchDataMap({ matchData, matchTitle, heroes }) {
+export default function MatchDataMap({
+  specificMatchData,
+  matchTitle,
+  heroes,
+}) {
+  const radiant = specificMatchData.players?.slice(0, 5);
+  const dire = specificMatchData.players?.slice(5);
   return (
     <div className="profile-div">
       <div className="match-title">{matchTitle}</div>
-      <div className="match-id">Match ID: {matchData.match_id}</div>
-      <div className="match-duration">{matchData.duration} Minutes</div>
-      <table>
-        <thead>
-          <tr>
-            <th>Hero</th>
-            <th>Kills</th>
-            <th>Deaths</th>
-            <th>Assists</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              {heroes[matchData.hero_id] && (
-                <div className="hero-img-name">
-                  <img
-                    src={`https://cdn.dota2.com${
-                      heroes[matchData.hero_id].img
-                    }`}
-                    alt={heroes[matchData.hero_id].localized_name}
-                  />
-                  {heroes[matchData.hero_id].localized_name}
-                </div>
-              )}
-            </td>
-            <td>{matchData.kills}</td>
-            <td>{matchData.deaths}</td>
-            <td>{matchData.assists}</td>
-          </tr>
-        </tbody>
-      </table>
+      <div className="match-id">Match ID: {specificMatchData.match_id}</div>
+      <div className="match-duration">
+        {Math.round(specificMatchData.duration / 60)} Minutes
+      </div>
+      <div>
+        <div className="team-victory">
+          {specificMatchData.radiant_win ? "Radiant Victory" : "Dire Victory"}
+        </div>
+        <div className="final-score">
+          {specificMatchData.radiant_score} | {specificMatchData.dire_score}
+        </div>
+      </div>
+      {specificMatchData && (
+        <div>
+          <div className="radiant-table">
+            <div className="team-name">Radiant</div>
+            <table className="radiant-players">
+              <thead>
+                <tr>
+                  <th>Player</th>
+                  <th>Hero</th>
+                  <th>Kills</th>
+                  <th>Deaths</th>
+                  <th>Assists</th>
+                  <th>Last Hits</th>
+                  <th>Denies</th>
+                  <th>Gold per Minute</th>
+                  <th>Total Gold</th>
+                  <th>Hero Damage</th>
+                  <th>Total Healing</th>
+                </tr>
+              </thead>
+              <tbody>
+                {radiant?.map((player, playerIndex) => (
+                  <tr key={playerIndex}>
+                    <td>
+                      {player.personaname
+                        ? player.personaname
+                        : '"Name not found"'}
+                    </td>
+                    <td>
+                      <div className="hero-img-name">
+                        <img
+                          src={`https://cdn.dota2.com${
+                            heroes[player.hero_id].img
+                          }`}
+                          alt={heroes[player.hero_id].localized_name}
+                        />
+                        {heroes[player.hero_id].localized_name}
+                      </div>
+                    </td>
+                    <td>{player.kills}</td>
+                    <td>{player.deaths}</td>
+                    <td>{player.assists}</td>
+                    <td>{player.last_hits}</td>
+                    <td>{player.denies}</td>
+                    <td>{player.gold_per_min}</td>
+                    <td>{player.total_gold}</td>
+                    <td>{player.hero_damage}</td>
+                    <td>{player.hero_healing}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="dire-table">
+            <div className="team-name">Dire</div>
+            <table className="dire-players">
+              <thead>
+                <tr>
+                  <th>Player</th>
+                  <th>Hero</th>
+                  <th>Kills</th>
+                  <th>Deaths</th>
+                  <th>Assists</th>
+                  <th>Last Hits</th>
+                  <th>Denies</th>
+                  <th>Gold per Minute</th>
+                  <th>Total Gold</th>
+                  <th>Hero Damage</th>
+                  <th>Total Healing</th>
+                </tr>
+              </thead>
+              <tbody>
+                {dire?.map((player, playerIndex) => (
+                  <tr key={playerIndex}>
+                    <td>
+                      {player.personaname
+                        ? player.personaname
+                        : '"Name not found"'}
+                    </td>
+                    <td>
+                      <div className="hero-img-name">
+                        <img
+                          src={`https://cdn.dota2.com${
+                            heroes[player.hero_id].img
+                          }`}
+                          alt={heroes[player.hero_id].localized_name}
+                        />
+                        {heroes[player.hero_id].localized_name}
+                      </div>
+                    </td>
+                    <td>{player.kills}</td>
+                    <td>{player.deaths}</td>
+                    <td>{player.assists}</td>
+                    <td>{player.last_hits}</td>
+                    <td>{player.denies}</td>
+                    <td>{player.gold_per_min}</td>
+                    <td>{player.total_gold}</td>
+                    <td>{player.hero_damage}</td>
+                    <td>{player.hero_healing}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/components/ResultsDisplay.jsx/MatchDataMap.jsx
+++ b/client/src/components/ResultsDisplay.jsx/MatchDataMap.jsx
@@ -1,9 +1,9 @@
 export default function MatchDataMap({ matchData, matchTitle, heroes }) {
   return (
     <div className="profile-div">
-      <h2>{matchTitle}</h2>
-      <h3>{matchData.match_id}</h3>
-      <h4>{matchData.duration} Minutes</h4>
+      <div className="match-title">{matchTitle}</div>
+      <div className="match-id">Match ID: {matchData.match_id}</div>
+      <div className="match-duration">{matchData.duration} Minutes</div>
       <table>
         <thead>
           <tr>
@@ -17,7 +17,7 @@ export default function MatchDataMap({ matchData, matchTitle, heroes }) {
           <tr>
             <td>
               {heroes[matchData.hero_id] && (
-                <>
+                <div className="hero-img-name">
                   <img
                     src={`https://cdn.dota2.com${
                       heroes[matchData.hero_id].img
@@ -25,7 +25,7 @@ export default function MatchDataMap({ matchData, matchTitle, heroes }) {
                     alt={heroes[matchData.hero_id].localized_name}
                   />
                   {heroes[matchData.hero_id].localized_name}
-                </>
+                </div>
               )}
             </td>
             <td>{matchData.kills}</td>

--- a/client/src/components/ResultsDisplay.jsx/ProfileData.jsx
+++ b/client/src/components/ResultsDisplay.jsx/ProfileData.jsx
@@ -1,15 +1,14 @@
 export default function ProfileData({ profile }) {
   return (
     <div className="profile-div">
-      <h2>Steam Profile</h2>
+      <h2>{profile.profile.personaname} Steam Profile</h2>
       <p>
-        Profile URL:{" "}
         <a
           href={profile.profile.profileurl}
           target="_blank"
           rel="noopener noreferrer"
         >
-          {profile.profile.profileurl}
+          Click here to go to Steam Profile
         </a>
       </p>
       <div className="profile-description-div">

--- a/client/src/components/ResultsDisplay.jsx/index.jsx
+++ b/client/src/components/ResultsDisplay.jsx/index.jsx
@@ -13,11 +13,13 @@ export default function ResultsDisplay() {
   const [results, setResults] = useState([]);
   const [heroes, setHeroes] = useState([]);
 
+  // useLocation is a custom hook that returns current location object, used to access location.state
   const location = useLocation();
 
   let steamId, longestMatch, shortestMatch;
 
   // Checks if location.state exists as they are undefined before if no state is passed in
+  // Needs parentheses within if statement to be considered an object literal to destructure vs no parentheses being a block statement
   if (location.state) {
     ({ steamId, longestMatch, shortestMatch } = location.state);
   }
@@ -50,7 +52,6 @@ export default function ResultsDisplay() {
 
   return (
     <div className="results-container">
-      {/* <h1>Search Results</h1> */}
       <MatchData
         profile={profile}
         matches={results}
@@ -59,12 +60,6 @@ export default function ResultsDisplay() {
         shortestMatch={shortestMatch}
         heroes={heroes}
       />
-      {/* {results &&
-        results.map((result) => (
-          <div key={result.match_id}>
-            <h2>{result.hero_id}</h2>
-          </div>
-        ))} */}
     </div>
   );
 }

--- a/client/src/components/ResultsDisplay.jsx/index.jsx
+++ b/client/src/components/ResultsDisplay.jsx/index.jsx
@@ -23,7 +23,7 @@ export default function ResultsDisplay() {
   }
 
   useEffect(() => {
-    async function fetchData() {
+    const fetchData = async () => {
       try {
         if (steamId) {
           const user = await playerProfileSearch(steamId);
@@ -39,7 +39,7 @@ export default function ResultsDisplay() {
       } catch (error) {
         console.error(error);
       }
-    }
+    };
 
     fetchData();
   }, [steamId, longestMatch, shortestMatch]);

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -54,3 +54,15 @@ export async function fetchHeroes() {
     console.error(error);
   }
 }
+
+export async function fetchMatch(match_id) {
+  try {
+    const response = await axios.get(
+      `https://api.opendota.com/api/matches/${match_id}`
+    );
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+}


### PR DESCRIPTION
- Axios request for specific match using a different API call created, and imported into MatchData.jsx
- Minor CSS changes for results page
- Removed state for longest/shortest matches data in MatchesData as it isn't required here. It is already retrieved in the useEffect fetchMatches function, and we just need the ID, not the entire array.
- Mapping data for all 10 players in a specific match, being split into 2 maps for styling purposes later.
- Added steam username in profile search results.