### PR TITLE
Search by match ID feature added, and added neutral items.

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -345,13 +345,22 @@ td {
   object-fit: cover;
 }
 
-.item-img {
+.item-img,
+.neutral-item-img {
   height: 50px;
+}
+
+.item-img {
   display: flex;
 }
 
-.item-img img {
+.item-img img,
+.neutral-item-img img {
   height: 70%;
+}
+
+.neutral-item-img img {
+  border-radius: 50%;
 }
 
 .name-column,

--- a/client/src/components/HomePage/ScrollText.jsx
+++ b/client/src/components/HomePage/ScrollText.jsx
@@ -34,7 +34,7 @@ export default function ScrollText({ videoRef }) {
               className="modal-button"
               onClick={() => setShowModal(!showModal)}
             >
-              Search By Player
+              Search Now!
             </button>
             <button className="video-button" onClick={pauseButton}>
               Play/Pause Video

--- a/client/src/components/HomePage/SearchModal.jsx
+++ b/client/src/components/HomePage/SearchModal.jsx
@@ -55,17 +55,22 @@ export default function SearchModal({ showModal, setShowModal }) {
         <button className="close-button" onClick={() => setShowModal(false)}>
           X
         </button>
+
         <div className="modal-content">
-          <div>Steam ID Search</div>
+          <div>Search</div>
           <div className="search-bar">
             <input
               type="text"
-              placeholder="Enter Steam ID or complete URL"
+              placeholder="Enter Steam ID, complete Steam URL, or match ID"
               value={steamId || matchId}
               onChange={(event) => {
-                event.target.value.length === 10
-                  ? setMatchId(event.target.value)
-                  : setSteamId(event.target.value);
+                if (!isNaN(event.target.value)) {
+                  setMatchId(event.target.value);
+                  setSteamId("");
+                } else {
+                  setSteamId(event.target.value);
+                  setMatchId("");
+                }
               }}
               onKeyDown={handleKeyDown}
               className="search-bar-input"
@@ -74,12 +79,17 @@ export default function SearchModal({ showModal, setShowModal }) {
               Search
             </button>
           </div>
+          {matchId.length === 10 && (
+            <div className="filter-match">
+              Filters don't work when searching by Match ID.
+            </div>
+          )}
           <div className="filter-div">
             <button
               className="search-id-button"
               onClick={() => setShowFilter(!showFilter)}
             >
-              Filter Results
+              Filter Profile Specific Results
             </button>
             {showFilter && <FilterCheckboxes filters={filters} />}
           </div>

--- a/client/src/components/HomePage/SearchModal.jsx
+++ b/client/src/components/HomePage/SearchModal.jsx
@@ -4,9 +4,10 @@ import { useNavigate } from "react-router-dom";
 import FilterCheckboxes from "./FilterCheckboxes";
 
 export default function SearchModal({ showModal, setShowModal }) {
-  const [showFilter, setShowFilter] = useState(false);
   const [steamId, setSteamId] = useState("");
+  const [matchId, setMatchId] = useState("");
 
+  const [showFilter, setShowFilter] = useState(false);
   const [recentMatch, setRecentMatch] = useState(false);
   const [longestMatch, setLongestMatch] = useState(false);
   const [shortestMatch, setShortestMatch] = useState(false);
@@ -38,7 +39,7 @@ export default function SearchModal({ showModal, setShowModal }) {
   const search = () => {
     // takes 2 args, path which is required, and optional state object
     navigate("/results", {
-      state: { steamId, recentMatch, longestMatch, shortestMatch },
+      state: { steamId, matchId, recentMatch, longestMatch, shortestMatch },
     });
   };
 
@@ -60,8 +61,12 @@ export default function SearchModal({ showModal, setShowModal }) {
             <input
               type="text"
               placeholder="Enter Steam ID or complete URL"
-              value={steamId}
-              onChange={(event) => setSteamId(event.target.value)}
+              value={steamId || matchId}
+              onChange={(event) => {
+                event.target.value.length === 10
+                  ? setMatchId(event.target.value)
+                  : setSteamId(event.target.value);
+              }}
               onKeyDown={handleKeyDown}
               className="search-bar-input"
             />

--- a/client/src/components/ResultsDisplay.jsx/MatchData.jsx
+++ b/client/src/components/ResultsDisplay.jsx/MatchData.jsx
@@ -7,13 +7,16 @@ import MatchDataMap from "./MatchDataMap";
 export default function MatchData({
   profile,
   matches,
+  searched,
   recentMatch,
   longestMatch,
   shortestMatch,
   heroes,
   items,
+  matchId,
 }) {
   // Specific matches use different API call for more indepth information on a match
+  const [specificSearchedMatch, setSpecificSearchedMatch] = useState([]);
   const [specificRecentMatch, setSpecificRecentMatch] = useState([]);
   const [specificLongestMatch, setSpecificLongestMatch] = useState([]);
   const [specificShortestMatch, setSpecificShortestMatch] = useState([]);
@@ -29,7 +32,19 @@ export default function MatchData({
       }
     };
 
+    // console.log("searched:", searched);
+    // console.log("heroes:", heroes);
+    // console.log("items:", items);
+
     const fetchMatches = async () => {
+      if (searched && searched.match_id) {
+        // console.log("searched.match_id:", searched.match_id);
+        const searchedMatchData = await fetchMatchData(searched.match_id);
+        // console.log("searchedMatchData:", searchedMatchData);
+        setSpecificSearchedMatch(searchedMatchData);
+        return;
+      }
+
       if (matches.length > 0) {
         let longest = matches[0];
         let shortest = matches[0];
@@ -71,16 +86,24 @@ export default function MatchData({
     };
 
     fetchMatches();
-  }, [matches, recentMatch, longestMatch, shortestMatch]);
+  }, [matches, searched, recentMatch, longestMatch, shortestMatch]);
 
-  if (!profile || !profile.profile) {
+  if (!profile && !profile.profile && !searched) {
     return;
   }
 
   return (
     <>
       {/* Uses both matchData and specificMatchData from different API calls. */}
-      {profile && <ProfileData profile={profile} />}
+      {profile && profile.profile && <ProfileData profile={profile} />}
+      {searched && searched.match_id && (
+        <MatchDataMap
+          specificMatchData={specificSearchedMatch}
+          matchTitle="Searched Match"
+          heroes={heroes}
+          items={items}
+        />
+      )}
       {recentMatch && heroes && (
         <MatchDataMap
           specificMatchData={specificRecentMatch}

--- a/client/src/components/ResultsDisplay.jsx/MatchData.jsx
+++ b/client/src/components/ResultsDisplay.jsx/MatchData.jsx
@@ -16,7 +16,6 @@ export default function MatchData({
   matchId,
 }) {
   // Specific matches use different API call for more indepth information on a match
-  const [specificSearchedMatch, setSpecificSearchedMatch] = useState([]);
   const [specificRecentMatch, setSpecificRecentMatch] = useState([]);
   const [specificLongestMatch, setSpecificLongestMatch] = useState([]);
   const [specificShortestMatch, setSpecificShortestMatch] = useState([]);
@@ -37,14 +36,6 @@ export default function MatchData({
     // console.log("items:", items);
 
     const fetchMatches = async () => {
-      if (searched && searched.match_id) {
-        // console.log("searched.match_id:", searched.match_id);
-        const searchedMatchData = await fetchMatchData(searched.match_id);
-        // console.log("searchedMatchData:", searchedMatchData);
-        setSpecificSearchedMatch(searchedMatchData);
-        return;
-      }
-
       if (matches.length > 0) {
         let longest = matches[0];
         let shortest = matches[0];
@@ -98,35 +89,39 @@ export default function MatchData({
       {profile && profile.profile && <ProfileData profile={profile} />}
       {searched && searched.match_id && (
         <MatchDataMap
-          specificMatchData={specificSearchedMatch}
+          specificMatchData={searched}
           matchTitle="Searched Match"
           heroes={heroes}
           items={items}
         />
       )}
-      {recentMatch && heroes && (
-        <MatchDataMap
-          specificMatchData={specificRecentMatch}
-          matchTitle="Most Recent Match"
-          heroes={heroes}
-          items={items}
-        />
-      )}
-      {longestMatch && heroes && (
-        <MatchDataMap
-          specificMatchData={specificLongestMatch}
-          matchTitle="Longest Match"
-          heroes={heroes}
-          items={items}
-        />
-      )}
-      {shortestMatch && heroes && (
-        <MatchDataMap
-          specificMatchData={specificShortestMatch}
-          matchTitle="Shortest Match"
-          heroes={heroes}
-          items={items}
-        />
+      {!matchId && (
+        <>
+          {recentMatch && heroes && (
+            <MatchDataMap
+              specificMatchData={specificRecentMatch}
+              matchTitle="Most Recent Match"
+              heroes={heroes}
+              items={items}
+            />
+          )}
+          {longestMatch && heroes && (
+            <MatchDataMap
+              specificMatchData={specificLongestMatch}
+              matchTitle="Longest Match"
+              heroes={heroes}
+              items={items}
+            />
+          )}
+          {shortestMatch && heroes && (
+            <MatchDataMap
+              specificMatchData={specificShortestMatch}
+              matchTitle="Shortest Match"
+              heroes={heroes}
+              items={items}
+            />
+          )}
+        </>
       )}
     </>
   );

--- a/client/src/components/ResultsDisplay.jsx/MatchDataMap.jsx
+++ b/client/src/components/ResultsDisplay.jsx/MatchDataMap.jsx
@@ -15,12 +15,12 @@ export default function MatchDataMap({
     "item_5",
   ];
 
-  console.log("MatchDataMap is being rendered");
-  console.log("specificMatchData:", specificMatchData);
-  console.log("radiant:", radiant);
-  console.log("dire:", dire);
-  console.log("heroes:", heroes);
-  console.log("items:", items);
+  // console.log("MatchDataMap is being rendered");
+  // console.log("specificMatchData:", specificMatchData);
+  // console.log("radiant:", radiant);
+  // console.log("dire:", dire);
+  // console.log("heroes:", heroes);
+  // console.log("items:", items);
 
   return (
     <div className="profile-div">

--- a/client/src/components/ResultsDisplay.jsx/MatchDataMap.jsx
+++ b/client/src/components/ResultsDisplay.jsx/MatchDataMap.jsx
@@ -4,8 +4,8 @@ export default function MatchDataMap({
   heroes,
   items,
 }) {
-  const radiant = specificMatchData.players?.slice(0, 5);
-  const dire = specificMatchData.players?.slice(5);
+  const radiant = specificMatchData.players?.slice(0, 5) || [];
+  const dire = specificMatchData.players?.slice(5) || [];
   const itemArray = [
     "item_0",
     "item_1",
@@ -14,6 +14,13 @@ export default function MatchDataMap({
     "item_4",
     "item_5",
   ];
+
+  console.log("MatchDataMap is being rendered");
+  console.log("specificMatchData:", specificMatchData);
+  console.log("radiant:", radiant);
+  console.log("dire:", dire);
+  console.log("heroes:", heroes);
+  console.log("items:", items);
 
   return (
     <div className="profile-div">
@@ -58,6 +65,7 @@ export default function MatchDataMap({
                     <th>Hero Damage</th>
                     <th>Total Healing</th>
                     <th>Items</th>
+                    <th>Neutral Item</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -101,8 +109,22 @@ export default function MatchDataMap({
                                     items[player[itemId]].img
                                   }`}
                                   alt={items[player[itemId]].dname}
+                                  title={items[player[itemId]].dname}
                                 />
                               )
+                          )}
+                        </div>
+                      </td>
+                      <td>
+                        <div className="neutral-item-img">
+                          {items[player["item_neutral"]] && (
+                            <img
+                              src={`https://cdn.dota2.com${
+                                items[player["item_neutral"]].img
+                              }`}
+                              alt={items[player["item_neutral"].dname]}
+                              title={items[player["item_neutral"]].dname}
+                            />
                           )}
                         </div>
                       </td>
@@ -130,6 +152,7 @@ export default function MatchDataMap({
                     <th>Hero Damage</th>
                     <th>Total Healing</th>
                     <th>Items</th>
+                    <th>Neutral Item</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -171,8 +194,22 @@ export default function MatchDataMap({
                                     items[player[itemId]].img
                                   }`}
                                   alt={items[player[itemId]].dname}
+                                  title={items[player[itemId]].dname}
                                 />
                               )
+                          )}
+                        </div>
+                      </td>
+                      <td>
+                        <div className="neutral-item-img">
+                          {items[player["item_neutral"]] && (
+                            <img
+                              src={`https://cdn.dota2.com${
+                                items[player["item_neutral"]].img
+                              }`}
+                              alt={items[player["item_neutral"].dname]}
+                              title={items[player["item_neutral"]].dname}
+                            />
                           )}
                         </div>
                       </td>

--- a/client/src/components/ResultsDisplay.jsx/index.jsx
+++ b/client/src/components/ResultsDisplay.jsx/index.jsx
@@ -6,6 +6,7 @@ import {
   playerIdSearch,
   fetchHeroes,
   fetchItems,
+  fetchMatch,
 } from "../../utils/API";
 
 import MatchData from "./MatchData";
@@ -13,6 +14,7 @@ import MatchData from "./MatchData";
 export default function ResultsDisplay() {
   const [profile, setProfile] = useState([]);
   const [results, setResults] = useState([]);
+  const [specificMatch, setSpecificMatch] = useState([]);
   const [heroes, setHeroes] = useState([]);
   const [items, setItems] = useState([]);
 
@@ -21,12 +23,13 @@ export default function ResultsDisplay() {
   // useLocation is a custom hook that returns current location object, used to access location.state
   const location = useLocation();
 
-  let steamId, recentMatch, longestMatch, shortestMatch;
+  let steamId, matchId, recentMatch, longestMatch, shortestMatch;
 
   // Checks if location.state exists as they are undefined before if no state is passed in
   // Needs parentheses within if statement to be considered an object literal to destructure vs no parentheses being a block statement
   if (location.state) {
-    ({ steamId, recentMatch, longestMatch, shortestMatch } = location.state);
+    ({ steamId, matchId, recentMatch, longestMatch, shortestMatch } =
+      location.state);
   }
 
   useEffect(() => {
@@ -45,6 +48,13 @@ export default function ResultsDisplay() {
             const itemsData = await fetchItems();
             setItems(itemsData);
           }
+        } else if (matchId) {
+          const match = await fetchMatch(matchId);
+          setSpecificMatch(match);
+          const heroesData = await fetchHeroes();
+          setHeroes(heroesData);
+          const itemsData = await fetchItems();
+          setItems(itemsData);
         }
       } catch (error) {
         console.error(error);
@@ -54,10 +64,10 @@ export default function ResultsDisplay() {
     };
 
     fetchData();
-  }, [steamId, recentMatch, longestMatch, shortestMatch]);
+  }, [steamId, matchId, recentMatch, longestMatch, shortestMatch]);
 
-  if (!steamId) {
-    return <h1>Please enter a Steam ID in the search bar.</h1>;
+  if (!steamId && !matchId) {
+    return <h1>Please enter a Steam ID or Match ID in the search bar.</h1>;
   }
 
   return (
@@ -72,6 +82,8 @@ export default function ResultsDisplay() {
           profile={profile}
           matches={results}
           steamId={steamId}
+          searched={specificMatch}
+          matchId={matchId}
           recentMatch={recentMatch}
           longestMatch={longestMatch}
           shortestMatch={shortestMatch}


### PR DESCRIPTION
- Added matchId to useNavigate on search modal, and useLocation on ResultsDisplay index.
- Mainly messed around with API call on MatchData, and ResultsDisplay index to display match specific stats.
- Data retrieved from search for specific match using fetchMatch API call is different than match data retrieved based off of SteamId. Had to change conditionals for if things such as steamId or matchId werent passed in for ResultsDisplay index. Same with conditional for if there isnt a profile or searched in MatchData. This was causing my searched match data map to not render.
- Added text that appears if 10 numbers are entered displaying that filters don't work with match ID search.